### PR TITLE
13 move previous readme to wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ TreeFlow is a JSON-to-code compiler that takes a JSON configuration file and use
 To generate your first data vizualisation application, you can use one of our samples. There are 9 samples included in this repository. 
 Start by cloning the repository then run the following commands:
 
-```
-// Install dependencies of the compiler
+```bash
+# Install dependencies of the compiler
 npm install 
 
-// Run one of the samples below
+# Run one of the samples below
 npm run sample-1
 npm run sample-2
 npm run sample-3
@@ -35,20 +35,18 @@ npm run sample-7
 npm run sample-8
 npm run sample-9
 
-// the above command will have generated an app folder
+# the above command will have generated an app folder
 cd app
 
-// install dependencies of the generated app
+# install dependencies of the generated app
 npm install
 
-// Start the node server
+# Start the node server
 node index.js 
 
-// For sample 3, 4, 5, 6, you can use the included Data-Mocker to generate data for the graphs
-// In a different shell while the server is running, run
-node app/Data-Mocker.js
+# For sample 3, 4, 5, 6, you can use the included Data-Mocker to generate data for the graphs
+# In a different shell while the server is running, run
+node Data-Mocker.js
 ```
 
 Your generated application should now be hosted on localhost:3000! 
- 
-

--- a/README.md
+++ b/README.md
@@ -11,36 +11,20 @@
 ## Introduction
 
 TreeFlow is a generic visualization library that utilizes React.js, Mobx.js, Node.js and Socket.io to generate dynamic and synchronized front end view of JData. The main advantage of using this technology stack is that it utilizes the concept of one-way data flow (so-called one-way binding) and component hierarchy of React framework so that the view is synchronized with any JData flow and the user can dynamically change the view structure by reorganizing the components with standard APIs.
-The overview of the stack works as follows: 
-Node.js, which in this case a JNode service, is the main controller that sets up socket.io and hosts view assets after Webpack-ing React component. It provides a main entry point to the TreeFlow service.
-socket.io is hosted by Node.js when the Node service starts to run. It is a wrap up of Websocket APIs of the TCP socket. It will act as a messaging hub for JData in-flow and Treeflow out-flow.
-Mobx.js is the data layer of all non-stateless React components. It tells when and what the react components should render.
-React.js is the main Treeflow layer that communicates with the client. It includes two important libraries, TreeFlow Components and ECharts Adaptor. TreeFlow Components include all the default  React components written in ES6 that can be reused anytime, including basic Form and Text input to Calendar Selector. The style sheets are included for all the components as well using LESS, so the colour scheme and layout can be changed dynamically based on client preference and demand as well. ECharts Adaptor is a wrap up library of ECharts 2.0, an open source library built by Baidu.inc, to match with TreeFlow APIs.
 
-![](/doc/RMSN.jpg)
+TreeFlow is a JSON-to-code compiler that takes a JSON configuration file and uses it to compile a data vizualisation application. Example of available configurations can be found in the wiki.
 
-## How it works
 
-The overview of the stack works as follows: 
+## Getting Started
 
-- Node.js, which in this case a node service, is the main controller that sets up socket.io and hosts view assets after Webpack-ing React component. It provides a main entry point to the Treeflow service.
-- socket.io is hosted by Node.js when the Node service starts to run. It is a wrap up of Websocket APIs of the TCP socket. It will act as a messaging hub for data in-flow and view out-flow.
-- Mobx.js is the data layer of all non-stateless React components. It tells when and what the react components should render.
-- React.js is the main View layer that communicates with the client. It includes two important libraries, View Components and ECharts Adaptor. View Components include all the default  React components written in ES6 that can be reused anytime, including basic Form and Text input to Calendar Selector. The style sheets are included for all the components as well using LESS, so the colour scheme and layout can be changed dynamically based on client preference and demand as well. ECharts Adaptor is a wrap up library of ECharts 2.0, an open source library built by Baidu.inc, to match with View APIs.
+To generate your first data vizualisation application, you can use one of our samples. There are 9 samples included in this repository. 
+Start by cloning the repository then run the following commands:
 
-## To Test:
 ```
-// Generate from Config.json
-npm test 
-// Open the directory Generated
-cd app
-// install all dependencies
-npm install
-// Starts node server
-node index.js 
+// Install dependencies of the compiler
+npm install 
 
-------------------
-// to run other Samples/Demos
+// Run one of the samples below
 npm run sample-1
 npm run sample-2
 npm run sample-3
@@ -51,23 +35,20 @@ npm run sample-7
 npm run sample-8
 npm run sample-9
 
-//then checkout ./app folder
-// or host files
-node app/index.js
+// the above command will have generated an app folder
+cd app
 
-// run socket data-mocker, for sample 3, 4, 5, 6
+// install dependencies of the generated app
+npm install
+
+// Start the node server
+node index.js 
+
+// For sample 3, 4, 5, 6, you can use the included Data-Mocker to generate data for the graphs
+// In a different shell while the server is running, run
 node app/Data-Mocker.js
-
-------------------
-// to read beautified code, run this after compilation and generation of the app folder
-npm run beautify
 ```
 
-## Updates
-
-- [x] Bug Fixes
-- [x] Newly added topology diagram:
-
-![](/doc/topology.gif)
+Your generated application should now be hosted on localhost:3000! 
  
 


### PR DESCRIPTION
closes #13 

See https://github.com/klaframboise/Treeflow.js/wiki/Intoduction for new Wiki location of previous README.md