### PR TITLE
22 Implemented bubble chart count mode generation capability

### DIFF
--- a/doc/Samples/11.Count-Bubble-Chart/Config.json
+++ b/doc/Samples/11.Count-Bubble-Chart/Config.json
@@ -1,0 +1,110 @@
+{
+  "package" : {
+    "name": "JView",
+    "version": "1.0.0",
+    "description": "A Simple JView system using React+Mobx+Node+MongoDB",
+    "author": "Carl Liu"
+  },
+  "path" : "./app",
+  "port" : "3000",
+  "pages" : [
+    {
+      "name" : "Data Panel",
+      "route" : "/data-panel",
+      "layout" : "default",
+      "panels" : [
+        {
+          "type": "FormSet",
+          "formList": [
+            {
+              "type": "select",
+              "dispLabel": "Device",
+              "param": "device",
+              "list": [
+                {"dispLabel": "Device1",
+                  "id": "M"
+                }, {"dispLabel": "Device2",
+                  "id": "H"
+                }, {"dispLabel": "Device3",
+                  "id": "L"
+                }, {"dispLabel": "Device4",
+                  "id": "Z"
+                }
+              ]
+            },
+            {
+              "type": "date",
+              "dispLabel" : "added Date",
+              "param": "date",
+              "isEn" :"true"
+            },
+            {
+              "type": "text",
+              "dispLabel": "X value",
+              "param": "xValue"
+            },
+            { "type": "text",
+              "dispLabel": "Y value",
+              "param": "yValue"
+            },
+            {
+              "type": "select",
+              "dispLabel": "Status",
+              "param": "status",
+              "list": [
+                {
+                  "dispLabel": "A",
+                  "id": "A"
+                },
+                {
+                  "dispLabel": "NA",
+                  "id": "NA"
+                }
+              ]
+            }
+          ],
+          "actionList": [
+            {
+            "type":"button",
+            "dispLabel": "Add",
+            "value": "",
+            "className": "btn-primary",
+            "trigger": "addData"
+          },
+            {
+              "type":"button",
+              "dispLabel": "Reset",
+              "value": "",
+              "className": "btn-default",
+              "trigger": "reset"
+            }],
+          "store": {
+            "device" : "0",
+            "xValue" : "0",
+            "yValue" : "0",
+            "status" : "0",
+            "date": "2017-6-6"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "Dashboard",
+      "route" : "/dashboard",
+      "layout" : "default",
+      "panels" : [
+        {
+          "type": "bubble",
+          "mode": "count",
+          "store": {
+            "socket":{
+              "id": "0",
+              "x" : "x",
+              "y" : "y"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/doc/Samples/11.Count-Bubble-Chart/Config.json
+++ b/doc/Samples/11.Count-Bubble-Chart/Config.json
@@ -96,6 +96,7 @@
         {
           "type": "bubble",
           "mode": "count",
+          "maxBubbleSize": 30,
           "store": {
             "socket":{
               "id": "0",

--- a/doc/Samples/11.Count-Bubble-Chart/Data-mocker.js
+++ b/doc/Samples/11.Count-Bubble-Chart/Data-mocker.js
@@ -1,0 +1,40 @@
+const io = require('socket.io-client');
+const socket = io('http://localhost:3000');
+
+const numDevices = 100
+const deviceDict = {};
+for (let i = 0; i < numDevices; i++) {
+    deviceDict[`device${i}`] = {
+        x: Math.random() * 100,
+        y: Math.random() * 100,
+        deviceId: `device${i}`
+    }
+}
+console.log('emitting initial dict');
+socket.emit('newDataPoints', {id: 0, centroids: Object.values(deviceDict)});
+
+setInterval(() => {
+    const updatedDevice = Math.floor(Math.random() * numDevices)
+    const deviceKey = `device${updatedDevice}`
+    const newX = clamp(randomize(deviceDict[deviceKey].x), 0, 100)
+    const newY = clamp(randomize(deviceDict[deviceKey].y), 0, 100)
+    deviceDict[deviceKey] = {x: newX, y: newY, deviceId: deviceKey};
+    console.log('emitting update for device', deviceKey);
+    socket.emit('newDataPoints', {id: 0, centroids: [deviceDict[deviceKey]]});
+    console.log('sent');
+}, 5000)
+
+/**
+ * Return a random value in range x +/- 10%
+ * @param {*} x 
+ */
+function randomize(x) {
+    const variance = 0.20;
+    const multiplier = Math.random() - 0.5;
+    const newValue = x + (x * variance * multiplier);
+    return newValue;
+}
+
+function clamp(x, min, max) {
+    return x < min ? min : (x > max ? max : x);
+}

--- a/doc/Samples/11.Count-Bubble-Chart/Data-mocker.js
+++ b/doc/Samples/11.Count-Bubble-Chart/Data-mocker.js
@@ -14,13 +14,18 @@ console.log('emitting initial dict');
 socket.emit('newDataPoints', {id: 0, centroids: Object.values(deviceDict)});
 
 setInterval(() => {
-    const updatedDevice = Math.floor(Math.random() * numDevices)
-    const deviceKey = `device${updatedDevice}`
-    const newX = clamp(randomize(deviceDict[deviceKey].x), 0, 100)
-    const newY = clamp(randomize(deviceDict[deviceKey].y), 0, 100)
-    deviceDict[deviceKey] = {x: newX, y: newY, deviceId: deviceKey};
-    console.log('emitting update for device', deviceKey);
-    socket.emit('newDataPoints', {id: 0, centroids: [deviceDict[deviceKey]]});
+    const updates = [];
+    for (let i = 0; i < Math.random() * 10; i++) {
+        const updatedDevice = Math.floor(Math.random() * numDevices)
+        const deviceKey = `device${updatedDevice}`
+        const newX = clamp(randomize(deviceDict[deviceKey].x), 0, 100)
+        const newY = clamp(randomize(deviceDict[deviceKey].y), 0, 100)
+        const update = {x: newX, y: newY, deviceId: deviceKey}
+        updates.push(update);
+        deviceDict[deviceKey] = update;
+    }
+    console.log('emitting update for', i, 'devices');
+    socket.emit('newDataPoints', {id: 0, centroids: updates});
     console.log('sent');
 }, 5000)
 

--- a/doc/Samples/12.Bubble-Chart-history-length/Config.json
+++ b/doc/Samples/12.Bubble-Chart-history-length/Config.json
@@ -1,0 +1,112 @@
+{
+  "package" : {
+    "name": "JView",
+    "version": "1.0.0",
+    "description": "A Simple JView system using React+Mobx+Node+MongoDB",
+    "author": "Carl Liu"
+  },
+  "path" : "./app",
+  "port" : "3000",
+  "pages" : [
+    {
+      "name" : "Data Panel",
+      "route" : "/data-panel",
+      "layout" : "default",
+      "panels" : [
+        {
+          "type": "FormSet",
+          "formList": [
+            {
+              "type": "select",
+              "dispLabel": "Device",
+              "param": "device",
+              "list": [
+                {"dispLabel": "Device1",
+                  "id": "M"
+                }, {"dispLabel": "Device2",
+                  "id": "H"
+                }, {"dispLabel": "Device3",
+                  "id": "L"
+                }, {"dispLabel": "Device4",
+                  "id": "Z"
+                }
+              ]
+            },
+            {
+              "type": "date",
+              "dispLabel" : "added Date",
+              "param": "date",
+              "isEn" :"true"
+            },
+            {
+              "type": "text",
+              "dispLabel": "X value",
+              "param": "xValue"
+            },
+            { "type": "text",
+              "dispLabel": "Y value",
+              "param": "yValue"
+            },
+            {
+              "type": "select",
+              "dispLabel": "Status",
+              "param": "status",
+              "list": [
+                {
+                  "dispLabel": "A",
+                  "id": "A"
+                },
+                {
+                  "dispLabel": "NA",
+                  "id": "NA"
+                }
+              ]
+            }
+          ],
+          "actionList": [
+            {
+            "type":"button",
+            "dispLabel": "Add",
+            "value": "",
+            "className": "btn-primary",
+            "trigger": "addData"
+          },
+            {
+              "type":"button",
+              "dispLabel": "Reset",
+              "value": "",
+              "className": "btn-default",
+              "trigger": "reset"
+            }],
+          "store": {
+            "device" : "0",
+            "xValue" : "0",
+            "yValue" : "0",
+            "status" : "0",
+            "date": "2017-6-6"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "Dashboard",
+      "route" : "/dashboard",
+      "layout" : "default",
+      "panels" : [
+        {
+          "type": "bubble",
+          "mode": "count",
+          "historyLength": 1,
+          "maxBubbleSize": 25,
+          "store": {
+            "socket":{
+              "id": "0",
+              "x" : "x",
+              "y" : "y"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/doc/Samples/12.Bubble-Chart-history-length/Data-mocker.js
+++ b/doc/Samples/12.Bubble-Chart-history-length/Data-mocker.js
@@ -1,0 +1,24 @@
+const io = require('socket.io-client');
+const socket = io('http://localhost:3000');
+
+const deviceDict = {
+    'device1': {
+        x: 10,
+        y: 10,
+        deviceId: `device1`
+    },
+    'device2': {
+        x: 90,
+        y: 90,
+        deviceId: `device2`
+    }
+};
+
+console.log('emitting initial dict');
+socket.emit('newDataPoints', {id: 0, centroids: Object.values(deviceDict)});
+
+setInterval(() => {
+    console.log('emitting update for device device1');
+    socket.emit('newDataPoints', {id: 0, centroids: [deviceDict['device1']]});
+    console.log('sent');
+}, 5000);

--- a/doc/Samples/13.Bubble-Chart-transition-period/Config.json
+++ b/doc/Samples/13.Bubble-Chart-transition-period/Config.json
@@ -1,0 +1,112 @@
+{
+  "package" : {
+    "name": "JView",
+    "version": "1.0.0",
+    "description": "A Simple JView system using React+Mobx+Node+MongoDB",
+    "author": "Carl Liu"
+  },
+  "path" : "./app",
+  "port" : "3000",
+  "pages" : [
+    {
+      "name" : "Data Panel",
+      "route" : "/data-panel",
+      "layout" : "default",
+      "panels" : [
+        {
+          "type": "FormSet",
+          "formList": [
+            {
+              "type": "select",
+              "dispLabel": "Device",
+              "param": "device",
+              "list": [
+                {"dispLabel": "Device1",
+                  "id": "M"
+                }, {"dispLabel": "Device2",
+                  "id": "H"
+                }, {"dispLabel": "Device3",
+                  "id": "L"
+                }, {"dispLabel": "Device4",
+                  "id": "Z"
+                }
+              ]
+            },
+            {
+              "type": "date",
+              "dispLabel" : "added Date",
+              "param": "date",
+              "isEn" :"true"
+            },
+            {
+              "type": "text",
+              "dispLabel": "X value",
+              "param": "xValue"
+            },
+            { "type": "text",
+              "dispLabel": "Y value",
+              "param": "yValue"
+            },
+            {
+              "type": "select",
+              "dispLabel": "Status",
+              "param": "status",
+              "list": [
+                {
+                  "dispLabel": "A",
+                  "id": "A"
+                },
+                {
+                  "dispLabel": "NA",
+                  "id": "NA"
+                }
+              ]
+            }
+          ],
+          "actionList": [
+            {
+            "type":"button",
+            "dispLabel": "Add",
+            "value": "",
+            "className": "btn-primary",
+            "trigger": "addData"
+          },
+            {
+              "type":"button",
+              "dispLabel": "Reset",
+              "value": "",
+              "className": "btn-default",
+              "trigger": "reset"
+            }],
+          "store": {
+            "device" : "0",
+            "xValue" : "0",
+            "yValue" : "0",
+            "status" : "0",
+            "date": "2017-6-6"
+          }
+        }
+      ]
+    },
+    {
+      "name" : "Dashboard",
+      "route" : "/dashboard",
+      "layout" : "default",
+      "panels" : [
+        {
+          "type": "bubble",
+          "mode": "count",
+          "transitionPeriod": 10,
+          "maxBubbleSize": 25,
+          "store": {
+            "socket":{
+              "id": "0",
+              "x" : "x",
+              "y" : "y"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/doc/Samples/13.Bubble-Chart-transition-period/Data-mocker.js
+++ b/doc/Samples/13.Bubble-Chart-transition-period/Data-mocker.js
@@ -1,0 +1,30 @@
+const io = require('socket.io-client');
+const socket = io('http://localhost:3000');
+
+const deviceDict = {
+    'device1': {
+        x: 10,
+        y: 10,
+        deviceId: `device1`
+    },
+    'device2': {
+        x: 90,
+        y: 90,
+        deviceId: `device2`
+    },
+    'device3': {
+        x: 91,
+        y: 91,
+        deviceId: `device3`
+    }
+};
+
+console.log('emitting initial dict');
+socket.emit('newDataPoints', {id: 0, centroids: Object.values(deviceDict)});
+
+setInterval(() => {
+    deviceDict['device3'] = {x: 10, y: 10, deviceId: 'device3'}
+    console.log('changing device3 to be clustered with device1');
+    socket.emit('newDataPoints', {id: 0, centroids: Object.values(deviceDict)});
+    console.log('sent');
+}, 5000);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
         "sample-8": "node Compiler.js doc/Samples/8.Max-Mem-Size/Config.json && cp doc/Samples/8.Max-Mem-Size/Data-mocker.js ./app",
         "sample-9": "node Compiler.js doc/Samples/9.Diagram/Config.json && cp doc/Samples/8.Max-Mem-Size/Data-mocker.js ./app",
         "sample-10": "node Compiler.js doc/Samples/10.Pre-Clustered-Bubble-Chart/Config.json && cp doc/Samples/10.Pre-Clustered-Bubble-Chart/Data-mocker.js ./app",
+        "sample-11": "node Compiler.js doc/Samples/11.Count-Bubble-Chart/Config.json && cp doc/Samples/11.Count-Bubble-Chart/Data-mocker.js ./app",
+        "sample-12": "node Compiler.js doc/Samples/12.Bubble-Chart-history-length/Config.json && cp doc/Samples/12.Bubble-Chart-history-length/Data-mocker.js ./app",
+        "sample-13": "node Compiler.js doc/Samples/13.Bubble-Chart-transition-period/Config.json && cp doc/Samples/13.Bubble-Chart-transition-period/Data-mocker.js ./app",
         "beautify": "find ./app -regex '.*\\.js' -exec js-beautify {} -r \\;"
     },
     "repository": {

--- a/utils/EchartAdaptor.js
+++ b/utils/EchartAdaptor.js
@@ -234,6 +234,7 @@ module.exports = {
     bubble: function () {
 
         const data = [];
+        const that = this;
         this.array.forEach(element => data.push(element));
 
         const option = {
@@ -260,13 +261,13 @@ module.exports = {
                 data: data,
                 type: 'scatter',
                 symbolSize: function (data) {
-                    return data[2];
+                    return (data[2] / that.maxValue) * that.maxSize;
                 },
                 emphasis: {
                     label: {
                         show: true,
                         formatter: function (param) {
-                            return param.data[3];
+                            return `${param.data[2]} devices contributing`;
                         },
                         position: 'top'
                     }

--- a/utils/EchartAdaptor.js
+++ b/utils/EchartAdaptor.js
@@ -236,6 +236,10 @@ module.exports = {
         const data = [];
         const that = this;
         this.array.forEach(element => data.push(element));
+        data.sort((firstEl, secondEl) =>{
+            const distToZero = (x, y) => Math.sqrt(x*x + y*y);
+            return distToZero(firstEl[0], firstEl[1]) - distToZero(secondEl[0] - secondEl[1]);
+        });
 
         const option = {
             title: {

--- a/utils/code-blocks/assignTransitioningDevices.js
+++ b/utils/code-blocks/assignTransitioningDevices.js
@@ -1,0 +1,25 @@
+/**
+ * This function assigns each device in the old device dict to the closest
+ * cluster. If the new value of the device is already in that cluster, do
+ * not add the old device.
+ * @param {*} fitted 
+ */
+function assignTransitioningDevices(fitted) {
+    for (const oldDeviceId in store.oldDeviceDict) {
+        const oldDevice = store.oldDeviceDict[oldDeviceId];
+        const oldDevicePos = [oldDevice[0], oldDevice[1]];
+        let bestCentroidIndex = 0;
+        let distToBestCentroid = getDistance(fitted[0][0].centroid, oldDevicePos);
+        for (let i = 1; i < fitted[0].length; i++) {
+            const distToThisCentroid = getDistance(fitted[0][1].centroid, oldDevicePos);
+            if (distToThisCentroid < distToBestCentroid) {
+                bestCentroidIndex = i;
+                distToBestCentroid = distToThisCentroid;
+            }
+        }
+        const bestCentroid = fitted[0][bestCentroidIndex];
+        if (!bestCentroid.points.find((point) => point[2] === oldDeviceId.split('__')[0])) {
+            bestCentroid.points.push([oldDevice])
+        }
+    }
+}

--- a/utils/code-blocks/historyLengthInterval.js
+++ b/utils/code-blocks/historyLengthInterval.js
@@ -1,0 +1,16 @@
+/*
+ * History length handling code. Every 30 seconds, check the list of device
+ * and remove any device that did not receive an update in the last historyLength.
+ */
+const historyLength = 60 * 60 * 1000;
+setInterval(() => {
+    const now = Date.now();
+    for (const device in store.deviceDict) {
+        if (store.deviceDict[device][3] < now - historyLength) {
+            delete store.deviceDict[device];
+        }
+    }
+    const points = Object.values(store.deviceDict);
+    const fitted = fit(points, 10, 5);
+    store.array = fitted[0].map(fitResults => [fitResults.centroid[0], fitResults.centroid[1], fitResults.points.length]);
+}, 30000);

--- a/utils/code-blocks/meanShift.js
+++ b/utils/code-blocks/meanShift.js
@@ -1,0 +1,166 @@
+/*
+ * Mean shift algorithm code. Adapted from GitHub @easonyty 
+ * https://github.com/ytyeason/Visualization-on-Internet-of-Things/blob/master/app/Dashboard/meanShift.js
+ */
+function fit(data, radius, c_distance) {
+
+    // Naive initialization. 1 point = 1 centroid
+    var centroids = [];
+    for (let i = 0; i < data.length; i++) {
+        centroids[i] = data[i];
+    }
+
+    // Begin optimization
+    while (true) {
+        let new_centroids = [];
+        let new_centroids_points = [];
+
+        // For each cluster, add all points to it that are within the kernel size
+        for (let i = 0; i < centroids.length; i++) {
+
+            let in_bandwidth = [];
+            var centroid = centroids[i];
+            for (let i = 0; i < data.length; i++) {
+                if (getDistance(data[i], centroid) < radius) {
+                    in_bandwidth.push(data[i]);
+                }
+            }
+
+            // Find the average position of all points in kernel
+            let new_centroid = getAverage(in_bandwidth);
+            new_centroids.push(new_centroid);
+
+            // Save this step's clusters
+            let new_centroid_points = {};
+            new_centroid_points.centroid = new_centroid;
+            new_centroid_points.points = in_bandwidth;
+            new_centroids_points.push(new_centroid_points);
+        }
+
+        // Save previous centroid for optimization evaluation
+        var prev_centroids = JSON.parse(JSON.stringify(centroids));
+
+        // Remove duplicate cluster (two clusters within a 2*c_distance square)
+        var uniques = removeDupFromMultiArr(new_centroids, c_distance);
+
+        // Check if clusters changed. If not, the solution is optimized. 
+        centroids = [];
+        for (let i = 0; i < uniques.length; i++) {
+            centroids[i] = uniques[i].centroid;
+        }
+        var optimized = true;
+        for (let i = 0; i < centroids.length; i++) {
+            if (!arraysEqual(centroids[i], prev_centroids[i])) {
+                optimized = false;
+            }
+            if (!optimized) {
+                break;
+            }
+        }
+        if (optimized) {
+            // Rebuild list of contributing devices per cluster and return.
+            return [buildCentroidPoints(centroids, data), centroids];
+        }
+
+    }
+}
+
+function removeDupFromMultiArr(arr, distance) {
+
+    var uniques = [];
+    var centroid_distance = distance;
+
+    for (var i = 0; i < arr.length; i++) {
+
+        let unique = true;
+        for (var j = 0; j < uniques.length; j++) {
+
+            const uniqueCentroid = uniques[j].centroid;
+            if ((Math.abs(arr[i][0]-uniqueCentroid[0])<centroid_distance)&&(Math.abs(arr[i][1]-uniqueCentroid[1])<centroid_distance)) { //if within range of c_distance, abandon this center
+                unique = false;
+                uniques[j].absorbedCentroids.push(arr[i]);
+                break;
+            }
+        }
+
+        if (unique) {
+            uniques.push({centroid: arr[i], absorbedCentroids: []});
+        }
+
+    }
+
+    return uniques;
+
+}
+
+/**
+ * Get euclidean distance between 2 points.
+ * @param {*} arr1 [x, y]
+ * @param {*} arr2 [x, y]
+ */
+function getDistance(arr1, arr2) {
+    var diff_x = arr1[0] - arr2[0];
+    var diff_y = arr1[1] - arr2[1];
+    var dis_square = diff_x * diff_x + diff_y * diff_y;
+    return Math.sqrt(dis_square);
+}
+
+/**
+ * Get the average x and y values of all points in arr
+ * @param {*} arr [[x, y]]
+ */
+function getAverage(arr) {
+    var num = arr.length;
+    var sum_x = 0;
+    var sum_y = 0;
+
+    for (let i = 0; i < arr.length; i++) {
+        sum_x = sum_x + arr[i][0];
+        sum_y = sum_y + arr[i][1];
+    }
+
+    var x = sum_x / num;
+    var y = sum_y / num;
+    var tmp = [];
+    tmp.push(+(x.toFixed(2)));
+    tmp.push(+(y.toFixed(2)));
+
+    return tmp;
+}
+
+/**
+ * Compare two arrays. Return true if they are equal.
+ * @param {*} a1 
+ * @param {*} a2 
+ */
+function arraysEqual(a1, a2) {
+    return JSON.stringify(a1) === JSON.stringify(a2);
+}
+
+/**
+ * Assign each device to the closest cluster.
+ * @param {*} centroids 
+ * @param {*} data 
+ */
+function buildCentroidPoints(centroids, data) {
+    const deviceDict = {};
+    const centroidPoints = centroids.map(centroid => {
+        return {centroid, points: []};
+    });
+    for (const point of data) {
+        const pointPos = [point[0], point[1]];
+        const deviceId = point[2];
+        let closestCentroid = 0;
+        let closestCentroidDist = getDistance(pointPos, centroidPoints[0].centroid);
+        for (let i = 1; i < centroidPoints.length; i++) {
+            const distToThisCentroid = getDistance(pointPos, centroidPoints[i].centroid);
+            if (distToThisCentroid < closestCentroidDist) {
+                closestCentroid = i;
+                closestCentroidDist = distToThisCentroid;
+            }
+        }
+        centroidPoints[closestCentroid].points.push(point);
+        deviceDict[deviceId] = closestCentroid;
+    }
+    return centroidPoints;
+}


### PR DESCRIPTION
Support for bubble chart generation in count mode was added. The following panel options are supported, as per the technical design proposal:
* `historyLength`
* `transitionPeriod`
* `maxBubbleSize`

### 100 devices demo
For this demo, an initial dump of 100 device values is generator by the mocker. Every 5 seconds there after, between 0 and 10 device's x-y values are changed by +/- 10%.
https://www.loom.com/share/ffb0fb37a6eb4212879897e9ea93a41b

### historyLength demo
In this demo, historyLength is set to 1 minute. The data mocker initially loads 2 devices, one at (10, 10) and the other at (90, 90) resulting in 2 clusters of 1 device. The mocker keeps reporting the device at (10, 10) but no longer sends update for the device at (90, 90). After a minute, the device at (90, 90) expires and is removed from the plot.
https://www.loom.com/share/07edf0c208ef4407bae0d7bc2a56c251

### transitionPeriod demo
In this demo, transitionPeriod is set to 10 seconds. The data mocker initially loads 3 devices, one at (10, 10) and the other 2 at (90, 90) resulting in 2 clusters. The mocker then changes the value of the 3rd device to (10, 10) so it moves from the (90, 90) cluster to the (10, 10) cluster. The (90, 90) cluster still reports 2 devices reporting even though one of the devices is no longer in that cluster. The first update after the transition period is over, the extra device will be removed.
https://www.loom.com/share/7f79b61ec6ac4b25a0c5848bf9a426f9