### PR TITLE
Fixed logical bug with count mode implementation for bin chart

### DIFF
--- a/lib/histogram/histogram.js
+++ b/lib/histogram/histogram.js
@@ -139,20 +139,23 @@ export function computeBins2dHeatmap(dataXY, optOrMethod, numberOfBinsX, numberO
     });
 
     var data = [];
-    var index = 0;
+    var ymin = data_y.bins[0].x0;
     var stepY = data_y.bins[0].x1 - data_y.bins[0].x0;
     for (var i = 0; i < data_x.bins.length; i++) {
-        var sample = data_x.bins[i].sample;
         var y_bins = {}
-        for (var j = 0; j < sample.length; j++, index++){
-            var x = sample[j];
-            var y = dataY[index];
+        var xmax = data_x.bins[i].x1;
+        var xmin = data_x.bins[i].x0;
 
-            var y_bin = Math.floor((y - data_y.bins[0].x0)/stepY);
-            y_bins[y_bin] = (y_bins[y_bin]+1) || 1;
-        }
+        var filtered_arr = dataXY.filter(innerArray => (innerArray[0] < xmax && innerArray[0] >= xmin));
+        var y_arr = arrayColumn(filtered_arr, 1);
+
+        y_arr.forEach((y) => {
+            var y_bin = Math.floor((y - ymin) / stepY);
+            y_bins[y_bin] = (y_bins[y_bin] + 1) || 1;
+        });
+
         for (const [y_bin, count] of Object.entries(y_bins)) {
-            data.push([i, parseInt(y_bin), count])
+            data.push([i, parseInt(y_bin), count]);
         }
     }
 


### PR DESCRIPTION
Fixed bug with count mode implementation for bin chart.

Closes #37 

The following is a gif showing bin chart count mode in action after the fix. An initial grid of 100 devices. Up to 10 updated devices are generated every 5 seconds. The history length is set so that it checks every 20 seconds for devices that did not receive any update for 30 seconds. The values of x and y are generated with normal random values with mean equal to 50 and a standard deviation of 15.

![bin-chart-count-fix](https://user-images.githubusercontent.com/35753718/101236737-91e0de80-36a1-11eb-982b-3564b9380ca7.gif)